### PR TITLE
feat: add reference store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ LDFLAGS = -s -w \
 GOFLAGS = -trimpath -ldflags="$(LDFLAGS)"
 
 # passed to run-* targets
-RUN_ARGS = --job-directory ./tmp --log-level debug
+RUN_ARGS       = --job-directory ./tmp --log-level debug
+EXTRA_RUN_ARGS =
 
 ## help (prints target names with trailing "## comment")
 
@@ -45,11 +46,11 @@ lint: ## runs golangci-lint on source files
 
 .PHONY: run-local
 run-local: tmp build ## builds and runs texd in local mode
-	./$(TARGET) $(RUN_ARGS)
+	./$(TARGET) $(RUN_ARGS) $(EXTRA_RUN_ARGS)
 
 .PHONY: run-container
 run-container: tmp build ## builds and runs texd in container mode
-	./$(TARGET) $(RUN_ARGS) texlive/texlive:latest
+	./$(TARGET) $(RUN_ARGS) $(EXTRA_RUN_ARGS) texlive/texlive:latest
 
 
 ## testing
@@ -74,9 +75,9 @@ test-simple: tmp ## sends a simple document to a running instance
 test-multi: tmp ## sends a more complex document to a running instance
 	curl http://localhost:2201/render \
 		-F "input.tex=<testdata/multi/input.tex" \
-		-s -F "doc.tex=<testdata/multi/doc.tex" \
+		-F "doc.tex=<testdata/multi/doc.tex" \
 		-F "chapter/input.tex=<testdata/multi/chapter/input.tex" \
-		-o tmp/$@-$$(date +%F_%T)-$$$$
+		-s -o tmp/$@-$$(date +%F_%T)-$$$$
 
 .PHONY: test-missing
 test-missing: tmp ## send a broken document to a running instance

--- a/cmd/texd-render
+++ b/cmd/texd-render
@@ -2,6 +2,8 @@
 
 from typing import Union
 
+from base64 import urlsafe_b64encode
+from hashlib import sha256
 from os import path, pathsep
 import sys
 
@@ -10,6 +12,16 @@ import json
 import requests
 
 import argparse
+
+def refhash(filename: str) -> str:
+    '''refhash calculates the file rerference hash for the given file.'''
+    h = sha256()
+    with open(filename, 'rb') as f:
+        for block in iter(lambda: f.read(4096), b''):
+            h.update(block)
+
+    digest = urlsafe_b64encode(h.digest()).decode('ascii')
+    return f'sha256:{digest}'
 
 def parse_file_arg(arg: str) -> list[str]:
     '''
@@ -27,14 +39,21 @@ def parse_file_arg(arg: str) -> list[str]:
     return parts
 
 FileList    = Union[list[tuple[str, str]], None]
+RefList     = Union[list[tuple[str, str, str]], None]
 
-def create_parts(files: FileList = None):
+def create_parts(files: FileList = None,
+                 refs: RefList = None,
+                 missing: list[str] = []):
     '''
-    create_parts assembles `files` into a multipart/form-data
+    create_parts assembles files and file references into a multipart/form-data
     body suitable for requests.post.
+
+    The file references (`refs`) are only included as whole, if their reference
+    hash is not in the missing list.
     '''
 
     if files == None: files = []
+    if refs == None: refs = []
 
     parts = {}
     num   = 0
@@ -45,17 +64,50 @@ def create_parts(files: FileList = None):
         parts[form_name] = (form_name, open(input_file, 'rb'), 'application/octet-stream')
         num += 1
 
+    for f in refs:
+        (form_name, input_file, ref) = f
+        if ref in missing:
+            print(f'part {num}: {input_file} as {form_name} (storing as {ref}')
+            parts[form_name] = (form_name, open(input_file, 'rb'), 'application/x.texd; ref=store')
+        else:
+            print(f'part {num}: {input_file} as {form_name} (using ref {ref}')
+            parts[form_name] = (form_name, ref, 'application/x.texd; ref=use')
+        num += 1
+
     return parts
 
 
-def render_document(url: str, files: FileList = []) -> requests.Response:
+def missing_refs(r: requests.Response) -> list[str]:
+    '''
+    missing_refs extracts the missing file references from a request.response.
+
+    (Note: this is not a generic function for arbitrary request.Response
+    objects, but tailored to a specific JSON response from texd.)
+    '''
+    if r.status_code == 422 and r.headers['Content-Type'].startswith('application/json'):
+        if (err := r.json()) and err.get('category', None) == 'reference':
+            return err['references']
+    return []
+
+
+def render_document(url: str, files: FileList = [], refs: RefList = None) -> requests.Response:
     '''
     render_document sends an HTTP POST request to the given URL.
 
-    The request body includes all files as multipart/form-data entries.
+    The request body includes all files as multipart/form-data entries, plus
+    (initially) the reference hashes of all references in `refs`.
+
+    If file references are provided and texd answers with a list of unknown
+    references, the request is retried once (this time with all missing
+    file references resolved).
     '''
-    parts = create_parts(files=files)
+    parts = create_parts(files=files, refs=refs)
     r = requests.post(url, files=parts)
+
+    if (missing := missing_refs(r)) and len(missing) > 0:
+        parts = create_parts(files=files, refs=refs, missing=missing)
+        print('missing references, retrying')
+        r = requests.post(url, files=parts)
 
     return r
 
@@ -69,13 +121,15 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Simple command line tool to interface with a texd server',
         epilog=f'''
-            At least one FILE must be given.
-            The FILE arguments take the format "path" or "path{pathsep}name,
+            At least one FILE or REF must be given.
+            Both FILE and REF arguments take the format "path" or "path{pathsep}name,
             where "path" is the local path to the file, and "name" is the file name
             to be used on the server, and default to "basename(path)".
         ''')
     parser.add_argument('--files', nargs='+', metavar='FILE', type=str, default=[],
                         help='one or more file to send to the server')
+    parser.add_argument('--refs', nargs='+', metavar='REF', type=str, default=[],
+                        help=f'one or more file references to use')
     parser.add_argument('--addr', nargs=1, metavar='URI', type=str, default='http://localhost:2201/',
                         help='address of texd server instance (defaults to http://localhost:2201/)')
     parser.add_argument('--error-format', dest="errfmt", nargs=1, type=str, choices=('json', 'full', 'condensed'),
@@ -89,7 +143,12 @@ if __name__ == '__main__':
         [input_file, form_name] = parse_file_arg(f)
         file_args.append((form_name, input_file))
 
-    if len(file_args) == 0:
+    ref_args: RefList = []
+    for ref in args.refs:
+        [input_file, form_name] = parse_file_arg(ref)
+        ref_args.append((form_name, input_file, refhash(input_file)))
+
+    if len(file_args) + len(ref_args) == 0:
         parser.print_help()
         exit(2)
 
@@ -98,7 +157,7 @@ if __name__ == '__main__':
     if (errfmt := args.errfmt) and errfmt != None:
         url = url._replace(query=f'errors={errfmt[0]}')
 
-    r = render_document(url.geturl(), files=file_args)
+    r = render_document(url.geturl(), files=file_args, refs=ref_args)
 
     if r.status_code == 200:
         if args.output == '-':

--- a/debian/texd-refhash
+++ b/debian/texd-refhash
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+'''
+Synopsis:
+
+  texd-refhash FILE [FILE [...]]
+
+This will print the texd file reference hash for each FILE, separated
+by a new line.
+'''
+
+from base64 import urlsafe_b64encode
+from hashlib import sha256
+from sys import argv
+
+def refhash(filename: str):
+  h = sha256()
+  with open(filename, 'rb') as f:
+    for block in iter(lambda: f.read(4096), b''):
+        h.update(block)
+
+  digest = urlsafe_b64encode(h.digest()).decode('ascii')
+  return f'sha256:{digest}'
+
+if __name__ == '__main__':
+  for file in argv[1:]:
+    print(refhash(file))

--- a/refstore/dir/dir_store.go
+++ b/refstore/dir/dir_store.go
@@ -65,6 +65,11 @@ func NewMemory(config *url.URL) (refstore.Adapter, error) {
 	return a, nil
 }
 
+func (d *dir) Exists(id refstore.Identifier) bool {
+	_, err := d.fs.Stat(d.idPath(id))
+	return err == nil
+}
+
 func configurePath(config *url.URL) string {
 	path := config.Path
 	if config.Host == "." {

--- a/refstore/dir/dir_store.go
+++ b/refstore/dir/dir_store.go
@@ -1,0 +1,105 @@
+// Package dir implements an on-disk reference storage adapter.
+//
+// To use it, add a anonymous import to your main package:
+//
+//	import (
+//		_ "github.com/digineo/texd/refstore/dir"
+//	)
+//
+// For configuration, use a DSN with the following shape:
+//
+//	dsn := "dir:///path/for/persistent/files?options"
+//	dir, _ := refstore.NewStore(dsn)
+//
+// Note the triple-slash: the scheme is "dir://", and the directory
+// itself is /path/for/persistent/files. See New() for valid options.
+package dir
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/digineo/texd/internal"
+	"github.com/digineo/texd/refstore"
+	"github.com/spf13/afero"
+	"go.uber.org/zap"
+)
+
+func init() {
+	refstore.RegisterAdapter("dir", New)
+}
+
+type dir struct {
+	fs   afero.Fs
+	path string
+}
+
+// New returns a new storage adapter.
+//
+// The following options (config.Query()) are understood:
+// - none yet
+//
+// The config.Path must point to an existing directory, and it must be
+// writable.
+func New(config *url.URL) (refstore.Adapter, error) {
+	a := &dir{
+		fs:   afero.OsFs{},
+		path: configurePath(config),
+	}
+	if err := internal.EnsureWritable(a.fs, a.path); err != nil {
+		return nil, fmt.Errorf("path %q not writable: %w", a.path, err)
+	}
+	return a, nil
+}
+
+func NewMemory(config *url.URL) (refstore.Adapter, error) {
+	a := &dir{
+		fs:   afero.NewMemMapFs(),
+		path: configurePath(config),
+	}
+	_ = a.fs.MkdirAll(a.path, 0o755)
+	return a, nil
+}
+
+func configurePath(config *url.URL) string {
+	path := config.Path
+	if config.Host == "." {
+		path = filepath.Join(".", path)
+	}
+	return path
+}
+
+func (d *dir) CopyFile(log *zap.Logger, id refstore.Identifier, dst io.Writer) error {
+	src, err := d.fs.Open(d.idPath(id))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return refstore.ErrUnknownReference
+		}
+		return fmt.Errorf("unexpected error when accessing storage object: %v", err)
+	}
+	defer src.Close()
+
+	log.Debug("copy file",
+		zap.String("refstore", "disk"),
+		zap.String("id", id.Raw()))
+	if _, err := io.Copy(dst, src); err != nil {
+		return fmt.Errorf("failed to copy storage object: %v", err)
+	}
+	return nil
+}
+
+func (d *dir) Store(log *zap.Logger, contents []byte) error {
+	id := refstore.NewIdentifier(contents)
+	log.Debug("store file",
+		zap.String("refstore", "disk"),
+		zap.String("id", id.Raw()))
+
+	if err := afero.WriteFile(d.fs, d.idPath(id), contents, 0o600); err != nil {
+		return fmt.Errorf("failed to create storage object: %v", err)
+	}
+	return nil
+}

--- a/refstore/dir/id_path.go
+++ b/refstore/dir/id_path.go
@@ -1,0 +1,11 @@
+package dir
+
+import (
+	"path/filepath"
+
+	"github.com/digineo/texd/refstore"
+)
+
+func (d *dir) idPath(id refstore.Identifier) string {
+	return filepath.Join(d.path, id.Raw())
+}

--- a/refstore/identifier.go
+++ b/refstore/identifier.go
@@ -1,0 +1,96 @@
+package refstore
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log"
+)
+
+type ErrInvalidIdentifier struct {
+	msg   string
+	cause error
+}
+
+func (err *ErrInvalidIdentifier) Error() string {
+	if err.cause == nil {
+		return fmt.Sprintf("invalid identifier: %v", err.msg)
+	}
+	return fmt.Sprintf("invalid identifier: %s: %v", err.msg, err.cause)
+}
+
+func (err *ErrInvalidIdentifier) Unwrap() error {
+	return err.cause
+}
+
+// File references are identified by their checksum.
+type Identifier []byte
+
+var (
+	prefix = []byte("sha256:")
+	plen   = len(prefix)
+	stdlen = base64.StdEncoding.EncodedLen(sha256.Size)    // 44 bytes, incl. 1 byte padding
+	rawlen = base64.RawStdEncoding.EncodedLen(sha256.Size) // 43 bytes
+)
+
+func (id Identifier) String() string {
+	return "sha256:" + id.Raw()
+}
+
+func (id Identifier) Raw() string {
+	return base64.RawURLEncoding.EncodeToString(id)
+}
+
+// ParseIdentifier takes an input in the form "sha256:...." and transforms it
+// into an Identifier. Parsing errors are reported as ErrInvalidIdentifier.
+func ParseIdentifier(b []byte) (Identifier, error) {
+	n := len(b)
+	if n != rawlen+plen && n != stdlen+plen {
+		return nil, &ErrInvalidIdentifier{msg: "unexpected input length"}
+	}
+	if !bytes.HasPrefix(b, prefix) {
+		return nil, &ErrInvalidIdentifier{msg: "missing hash prefix"}
+	}
+	if n == stdlen+plen && b[n-1] != byte(base64.StdPadding) {
+		return nil, &ErrInvalidIdentifier{msg: "unexpected non-padding character at the end"}
+	}
+
+	// remove prefix and padding
+	b = b[len(prefix):]
+
+	// remove padding character(s)
+	if i := bytes.IndexRune(b, base64.StdPadding); i >= 0 {
+		b = b[:i]
+	}
+
+	dec := base64.RawURLEncoding
+	if bytes.ContainsAny(b, "+/") {
+		dec = base64.RawStdEncoding
+	}
+
+	id, err := dec.DecodeString(string(b))
+	if err != nil {
+		return nil, &ErrInvalidIdentifier{"decoding failed", err}
+	} else if len(id) != sha256.Size {
+		log.Println(len(id), sha256.Size)
+		return nil, &ErrInvalidIdentifier{msg: "decoding failed: unexpected output length"}
+	}
+	return id, nil
+}
+
+// NewIdentifier calculates the reference ID from the given file contents.
+func NewIdentifier(contents []byte) Identifier {
+	h := sha256.Sum256(contents)
+	return Identifier(h[:])
+}
+
+func ReadIdentifier(r io.Reader) (Identifier, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return nil, err
+	}
+	id := h.Sum(nil)
+	return Identifier(id), nil
+}

--- a/refstore/identifier_test.go
+++ b/refstore/identifier_test.go
@@ -1,0 +1,65 @@
+package refstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIdentifier(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		input string // input to ParseIdentifier
+		raw   string // result of Identifier.Raw()
+		err   string // expected error
+	}{
+		"input empty": {
+			input: "",
+			err:   "invalid identifier: unexpected input length",
+		},
+		"input too short": {
+			input: "sha256:aaaaaaaaa-bbbbbbbbb000000000zzzzzzzzz-ABCD",
+			err:   "invalid identifier: unexpected input length",
+		},
+		"input too long": {
+			input: "sha256:aaaaaaaaa-bbbbbbbbb000000000zzzzzzzzz-ABCDEXYX",
+			err:   "invalid identifier: unexpected input length",
+		},
+		"unexpected padding": {
+			input: "sha256:aaaaaaaaa-bbbbbbbbb000000000zzzzzzzzz-ABCDEX",
+			err:   "invalid identifier: unexpected non-padding character at the end",
+		},
+		"url encoding no padding": {
+			input: "sha256:aaaaaaaaa-bbbbbbbbb000000000zzzzzzzzz-ABCDE",
+			raw:   "aaaaaaaaa-bbbbbbbbb000000000zzzzzzzzz-ABCDE",
+		},
+		"url encoding": {
+			input: "sha256:aaaaaaaaa-bbbbbbbbb000000000zzzzzzzzz-ABCDE=",
+			raw:   "aaaaaaaaa-bbbbbbbbb000000000zzzzzzzzz-ABCDE",
+		},
+		"std encoding no padding": {
+			input: "sha256:aaaaaaaaa+bbbbbbbbb000000000zzzzzzzzz+ABCDE",
+			raw:   "aaaaaaaaa-bbbbbbbbb000000000zzzzzzzzz-ABCDE",
+		},
+		"std encoding": {
+			input: "sha256:aaaaaaaaa+bbbbbbbbb000000000zzzzzzzzz+ABCDE=",
+			raw:   "aaaaaaaaa-bbbbbbbbb000000000zzzzzzzzz-ABCDE",
+		},
+	} {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			id, err := ParseIdentifier([]byte(tc.input))
+			if tc.err != "" {
+				require.EqualError(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, string(prefix)+tc.raw, id.String())
+				assert.Equal(t, tc.raw, id.Raw())
+			}
+		})
+	}
+}

--- a/refstore/nop/nop_store.go
+++ b/refstore/nop/nop_store.go
@@ -1,0 +1,25 @@
+// Package nop implements a no-op reference store adapter.
+// It does nothing, can't be configured and can't be created with
+// refstore.NewStore.
+package nop
+
+import (
+	"io"
+
+	"github.com/digineo/texd/refstore"
+	"go.uber.org/zap"
+)
+
+type nop struct{}
+
+func New() (refstore.Adapter, error) {
+	return &nop{}, nil
+}
+
+func (*nop) CopyFile(*zap.Logger, refstore.Identifier, io.Writer) error {
+	return refstore.ErrUnknownReference
+}
+
+func (*nop) Store(*zap.Logger, []byte) error {
+	return nil
+}

--- a/refstore/nop/nop_store.go
+++ b/refstore/nop/nop_store.go
@@ -20,6 +20,11 @@ func (*nop) CopyFile(*zap.Logger, refstore.Identifier, io.Writer) error {
 	return refstore.ErrUnknownReference
 }
 
-func (*nop) Store(*zap.Logger, io.Reader) error {
-	return nil
+func (*nop) Store(_ *zap.Logger, r io.Reader) error {
+	_, err := io.Copy(io.Discard, r)
+	return err
+}
+
+func (*nop) Exists(refstore.Identifier) bool {
+	return false
 }

--- a/refstore/nop/nop_store.go
+++ b/refstore/nop/nop_store.go
@@ -20,6 +20,6 @@ func (*nop) CopyFile(*zap.Logger, refstore.Identifier, io.Writer) error {
 	return refstore.ErrUnknownReference
 }
 
-func (*nop) Store(*zap.Logger, []byte) error {
+func (*nop) Store(*zap.Logger, io.Reader) error {
 	return nil
 }

--- a/refstore/reference_store.go
+++ b/refstore/reference_store.go
@@ -15,7 +15,7 @@ type Adapter interface {
 	CopyFile(log *zap.Logger, id Identifier, w io.Writer) error
 
 	// Store saves the content in the adapter backend.
-	Store(log *zap.Logger, contents []byte) error
+	Store(log *zap.Logger, r io.Reader) error
 }
 
 var ErrUnknownReference = errors.New("unknown reference")

--- a/refstore/reference_store.go
+++ b/refstore/reference_store.go
@@ -1,0 +1,21 @@
+package refstore
+
+import (
+	"errors"
+	"io"
+
+	"go.uber.org/zap"
+)
+
+// The Adapter inteface describes the protocol to interact with different
+// storage backends.
+type Adapter interface {
+	// CopyFile copies a file with the given ID to the target path. It may
+	// return ErrUnknownReference if the ID is unknown.
+	CopyFile(log *zap.Logger, id Identifier, w io.Writer) error
+
+	// Store saves the content in the adapter backend.
+	Store(log *zap.Logger, contents []byte) error
+}
+
+var ErrUnknownReference = errors.New("unknown reference")

--- a/refstore/reference_store.go
+++ b/refstore/reference_store.go
@@ -16,6 +16,10 @@ type Adapter interface {
 
 	// Store saves the content in the adapter backend.
 	Store(log *zap.Logger, r io.Reader) error
+
+	// Exists checks whether the given reference identifier exists in this
+	// storage adapter.
+	Exists(id Identifier) bool
 }
 
 var ErrUnknownReference = errors.New("unknown reference")

--- a/refstore/registry.go
+++ b/refstore/registry.go
@@ -1,0 +1,64 @@
+package refstore
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"sync"
+)
+
+type AdapterConstructor func(*url.URL) (Adapter, error)
+
+type ErrStoreAlreadyTaken string
+
+func (err ErrStoreAlreadyTaken) Error() string {
+	return fmt.Sprintf("refstore: the name %q is already taken by another adapter package", string(err))
+}
+
+var (
+	stores  = map[string]AdapterConstructor{}
+	storeMu = sync.RWMutex{}
+)
+
+// RegisterAdapter will remember the given adapter with under the
+// given name. It will panic, if the name is already taken.
+func RegisterAdapter(name string, adapter AdapterConstructor) {
+	storeMu.Lock()
+	defer storeMu.Unlock()
+
+	if _, taken := stores[name]; taken {
+		panic(ErrStoreAlreadyTaken(name))
+	}
+	stores[name] = adapter
+}
+
+// NewStore creates a new reference store with the given DSN. The adapter
+// name is extracted from the DSN, i.e. the disk adapter requires a
+// DSN of the form "disk://".
+func NewStore(dsn string) (Adapter, error) {
+	storeMu.RLock()
+	defer storeMu.RUnlock()
+
+	uri, err := url.Parse(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("invalid DSN: %v", err)
+	}
+
+	constructor, exists := stores[uri.Scheme]
+	if !exists {
+		return nil, fmt.Errorf("unknown storage adapter %q", uri.Scheme)
+	}
+
+	return constructor(uri)
+}
+
+func AvailableAdapters() (list []string) {
+	storeMu.RLock()
+	defer storeMu.RUnlock()
+
+	for name := range stores {
+		list = append(list, name)
+	}
+	sort.Strings(list)
+	return
+}

--- a/service/renderer.go
+++ b/service/renderer.go
@@ -98,7 +98,8 @@ func (svc *service) render(log *zap.Logger, res http.ResponseWriter, req *http.R
 	}
 
 	if err = svc.executor(doc).Run(req.Context(), log); err != nil {
-		if format := params.Get("errors"); format != "" {
+		switch format := params.Get("errors"); format {
+		case "full", "condensed":
 			logReader, lerr := doc.GetLogs()
 			if lerr != nil {
 				log.Error("failed to get logs", zap.Error(lerr))
@@ -107,7 +108,6 @@ func (svc *service) render(log *zap.Logger, res http.ResponseWriter, req *http.R
 			logfileResponse(log, res, format, logReader)
 			return nil // header is already written
 		}
-
 		return err
 	}
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -191,7 +191,7 @@ var serviceTestCases = map[string]serviceTestCase{
 		statusCode:   http.StatusUnprocessableEntity,
 		mockParams:   mockParams{true, mockPDF},
 		expectedMIME: mimeTypeJSON,
-		expectedBody: `{"category":"input","content-type":"application/x.texd; ref=use","error":"failed to parse reference","name":"preamble.sty"}`,
+		expectedBody: `{"category":"input","content-type":"application/x.texd; ref=use","error":"failed to parse reference","name":"preamble.sty","part":1}`,
 	},
 	"reference store, use known file": {
 		refstore: func() refstore.Adapter {
@@ -199,10 +199,11 @@ var serviceTestCases = map[string]serviceTestCase{
 			if err != nil {
 				panic(err)
 			}
-			contents, err := os.ReadFile("../testdata/reference/preamble.sty")
+			contents, err := os.Open("../testdata/reference/preamble.sty")
 			if err != nil {
 				panic(err)
 			}
+			defer contents.Close()
 			if err = refs.Store(zap.NewNop(), contents); err != nil {
 				panic(err)
 			}

--- a/testdata/reference/input.tex
+++ b/testdata/reference/input.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage{preamble}
+\begin{document}
+  \Hello
+\end{document}

--- a/testdata/reference/preamble.sty
+++ b/testdata/reference/preamble.sty
@@ -1,0 +1,4 @@
+\ProvidesPackage{preamble}
+\NeedsTeXFormat{LaTeX2e}
+
+\def\Hello{Hello, world!}

--- a/tex/errors.go
+++ b/tex/errors.go
@@ -11,6 +11,7 @@ const (
 	inputErr errCategory = iota + 1
 	compilationErr
 	queueErr
+	referenceErr
 )
 
 func (cat errCategory) String() string {
@@ -21,6 +22,8 @@ func (cat errCategory) String() string {
 		return "compilation"
 	case queueErr:
 		return "queue"
+	case referenceErr:
+		return "reference"
 	default:
 		return "unknown"
 	}
@@ -41,6 +44,12 @@ func newCategoryError(cat errCategory, message string, cause error, extra KV) er
 
 func InputError(message string, cause error, extra KV) error {
 	return newCategoryError(inputErr, message, cause, extra)
+}
+
+func ReferenceError(references []string) error {
+	return newCategoryError(referenceErr, "unknown file references", nil, KV{
+		"references": references,
+	})
 }
 
 func CompilationError(message string, cause error, extra KV) error {

--- a/tex/errors.go
+++ b/tex/errors.go
@@ -38,6 +38,24 @@ type ErrWithCategory struct {
 	extra   KV
 }
 
+// ExtendError adds the given extra ke/value pairs to err, if err is a
+// ErrWithCategory. If extra is empty or err is another type of error,
+// this function does nothing.
+func ExtendError(err error, extra KV) {
+	if len(extra) == 0 {
+		return
+	}
+	if catErr, ok := err.(*ErrWithCategory); ok {
+		if catErr.extra == nil {
+			catErr.extra = extra
+			return
+		}
+		for k, v := range extra {
+			catErr.extra[k] = v
+		}
+	}
+}
+
 func newCategoryError(cat errCategory, message string, cause error, extra KV) error {
 	return &ErrWithCategory{cat: cat, message: message, cause: cause, extra: extra}
 }

--- a/tex/errors_test.go
+++ b/tex/errors_test.go
@@ -1,0 +1,103 @@
+package tex
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorWithCategory(t *testing.T) {
+	{
+		err := ErrWithCategory{message: "message"}
+		assert.EqualError(t, &err, "message")
+
+		json, marshal := err.MarshalJSON()
+		require.NoError(t, marshal)
+		assert.Equal(t, `{"category":"unknown","error":"message"}`, string(json))
+	}
+	{
+		err := ErrWithCategory{cat: inputErr, message: "message"}
+		assert.EqualError(t, &err, "message")
+
+		json, marshal := err.MarshalJSON()
+		require.NoError(t, marshal)
+		assert.Equal(t, `{"category":"input","error":"message"}`, string(json))
+	}
+	{
+		err := ErrWithCategory{message: "message", extra: KV{"foo": 42}}
+		assert.EqualError(t, &err, "message")
+
+		json, marshal := err.MarshalJSON()
+		require.NoError(t, marshal)
+		// extra data is appended
+		assert.Equal(t, `{"category":"unknown","error":"message","foo":42}`, string(json))
+	}
+	{
+		err := ErrWithCategory{message: "message", extra: KV{"foo": 42, "category": "a", "error": "b"}}
+		assert.EqualError(t, &err, "message")
+
+		json, marshal := err.MarshalJSON()
+		require.NoError(t, marshal)
+		// reserved keywords are omitted
+		assert.Equal(t, `{"category":"unknown","error":"message","foo":42}`, string(json))
+	}
+	{
+		err := ErrWithCategory{message: "message", cause: io.EOF}
+		// include cause
+		assert.EqualError(t, &err, "message: EOF")
+
+		json, marshal := err.MarshalJSON()
+		require.NoError(t, marshal)
+		// omit cause
+		assert.Equal(t, `{"category":"unknown","error":"message"}`, string(json))
+	}
+}
+
+func TestExtendError_blank(t *testing.T) {
+	{
+		err := InputError("message", nil, nil)
+		ExtendError(err, nil)
+		assert.Len(t, err.(*ErrWithCategory).extra, 0)
+	}
+	{
+		err := InputError("message", nil, KV{})
+		ExtendError(err, nil)
+		assert.Len(t, err.(*ErrWithCategory).extra, 0)
+	}
+	{
+		err := InputError("message", nil, nil)
+		ExtendError(err, KV{})
+		assert.Len(t, err.(*ErrWithCategory).extra, 0)
+	}
+	{
+		err := InputError("message", nil, KV{})
+		ExtendError(err, KV{})
+		assert.Len(t, err.(*ErrWithCategory).extra, 0)
+	}
+}
+
+func TestExtendError_extendsErr(t *testing.T) {
+	{
+		err := InputError("message", nil, nil)
+		ExtendError(err, KV{"foo": "bar"})
+		assert.Equal(t, "bar", err.(*ErrWithCategory).extra["foo"])
+	}
+	{
+		err := InputError("message", nil, KV{"foo": "bar"})
+		ExtendError(err, nil)
+		assert.Equal(t, "bar", err.(*ErrWithCategory).extra["foo"])
+	}
+	{
+		err := InputError("message", nil, KV{"foo": "original"})
+		ExtendError(err, KV{"foo": "bar"})
+		assert.Equal(t, "bar", err.(*ErrWithCategory).extra["foo"])
+	}
+}
+
+func TestExtendError_onlyCatErrors(t *testing.T) {
+	err := io.EOF
+	ExtendError(err, KV{"foo": "bar"})
+	assert.True(t, err == io.EOF)
+}


### PR DESCRIPTION
Mostly untested and likely broken.

To start locally, run:

```console
$ mkdir -p tmp/refs
$ make run-container EXTRA_RUN_ARGS="--reference-storage dir://$(pwd)/tmp/refs/"
```

Then, in `texd-ruby`, branch `refstore`, run:

```console
$ BUNDLE_GEMFILE=Gemfile-6.0 bundle exec rspec spec/lib/texd/render_spec.rb
```

Issue: #2