### PR TITLE
docs: fix typos

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,7 +30,7 @@ nfpms:
     homepage: https://github.com/digineo/texd
     maintainer: Dominik Menke <dom@digineo.de>
     description: |-
-      texd wraps a local TeX installion into a web service.
+      texd wraps a local TeX installation into a web service.
       Alternatively, texd executes each compilation job in an isolated
       Docker container.
     license: MIT
@@ -55,7 +55,7 @@ nfpms:
     maintainer: Dominik Menke <dom@digineo.de>
     description: |-
       texd-tools includes command line tools useful to interact with
-      a texd server. Currenty, the following tools are bundled:
+      a texd server. Currently, the following tools are bundled:
 
       * texd-render: an HTTP client to compile source files to PDF
     license: MIT

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ This is XeTeX, Version 3.141592653-2.6-0.999993 (TeX Live 2021) (preloaded forma
 entering extended mode
  restricted \write18 enabled.
  %&-line parsing enabled.
-... ommitting some lines ...
+... omitting some lines ...
 ! LaTeX Error: File `missing.tex' not found.
 
 Type X to quit or <RETURN> to proceed,
@@ -439,12 +439,12 @@ Anyway, consider the UI only as demonstrator for the API.
 
 ## Reference store
 
-texd has the ability to re-use previously sent material. This allows you to reduce the amount
+texd has the ability to reuse previously sent material. This allows you to reduce the amount
 of data you need to transmit with each render request. Following a back-of-the-envelope calculation:
 
 - If you want to generate 1000 documents, each including a font with 400 kB in size, and a logo
   file with 100 kB in size, you will need to transmit 500 MB of the same two files in total.
-- If you can re-use those two assets, you would only need to transmit them once, and use a reference
+- If you can reuse those two assets, you would only need to transmit them once, and use a reference
   hash for each subsequent request. The total then reduces 1×500 kB (complete assets for the first
   request) + 999×100 Byte (50 Byte per reference hash for subsequent requests) = 599.9 kB.
 
@@ -584,7 +584,7 @@ Notes:
 ## History
 
 texd came to life because I've build dozens of Rails applications, which all needed to build PDF
-documents in one form or another (from recipies, to invoices, order confirmations, reports and
+documents in one form or another (from recipes, to invoices, order confirmations, reports and
 technical documentation). Each server basically needed a local TeX installation (weighing in at
 several 100 MB, up to several GB). Compiling many LaTeX documents also became a bottleneck for
 applications running on otherwise modest hardware (or cloud VMs), as this process is also

--- a/cmd/texd-render
+++ b/cmd/texd-render
@@ -19,7 +19,7 @@ def log(message):
 
 
 def refhash(filename: str) -> str:
-    '''refhash calculates the file rerference hash for the given file.'''
+    '''refhash calculates the file reference hash for the given file.'''
     h = sha256()
     with open(filename, 'rb') as f:
         for block in iter(lambda: f.read(4096), b''):

--- a/exec/docker_client.go
+++ b/exec/docker_client.go
@@ -132,28 +132,28 @@ func (dc *DockerClient) findImage(ctx context.Context, tag string) (summary imag
 	return
 }
 
-type progess struct {
+type progress struct {
 	w    io.Writer
 	fd   uintptr
 	term bool
 }
 
-func newProgressReporter(out *os.File) *progess {
+func newProgressReporter(out *os.File) *progress {
 	fd := out.Fd()
-	return &progess{
+	return &progress{
 		w:    out,
 		fd:   fd,
 		term: term.IsTerminal(fd),
 	}
 }
 
-func (p *progess) report(r io.Reader) error {
+func (p *progress) report(r io.Reader) error {
 	return jsonmessage.DisplayJSONMessagesStream(r, p.w, p.fd, p.term, nil)
 }
 
 // pull pulls the given image tag. Progress is reported to p, unless
 // p is nil.
-func (dc *DockerClient) pull(ctx context.Context, tag string, p *progess) error {
+func (dc *DockerClient) pull(ctx context.Context, tag string, p *progress) error {
 	r, err := dc.cli.ImagePull(ctx, tag, image.PullOptions{})
 	if err != nil {
 		return err

--- a/exec/docker_client_test.go
+++ b/exec/docker_client_test.go
@@ -594,7 +594,7 @@ func (s *dockerClientSuite) TestRun_errContainerCreate() {
 	s.Assert().Equal("", out)
 }
 
-func (s *dockerClientSuite) TestRun_errRetreiveLogs() {
+func (s *dockerClientSuite) TestRun_errRetrieveLogs() {
 	const runningID = "7ea"
 	s.mockContainerCreate("texd", "/job", []string{"latexmk"},
 		runningID, nil)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -36,7 +36,7 @@ var (
 
 	OutputSize = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "texd_output_file_size_bytes",
-		Help:    "Overview of genereted document sizes, success only",
+		Help:    "Overview of generated document sizes, success only",
 		Buckets: prometheus.ExponentialBuckets(2048, 2, 13), // 2 KiB .. 8 MiB
 	})
 

--- a/refstore/memcached/memcached.go
+++ b/refstore/memcached/memcached.go
@@ -140,7 +140,7 @@ func (s *store) CopyFile(_ *zap.Logger, id refstore.Identifier, w io.Writer) err
 		if errors.Is(err, memcache.ErrCacheMiss) {
 			return refstore.ErrUnknownReference
 		}
-		return fmt.Errorf("memcached: failed to retreive storage object: %w", err)
+		return fmt.Errorf("memcached: failed to retrieve storage object: %w", err)
 	}
 
 	if _, err = io.Copy(w, bytes.NewReader(val)); err != nil {

--- a/service/assets/texd.js
+++ b/service/assets/texd.js
@@ -155,7 +155,7 @@ const app = Vue.createApp({
         } else {
           this.result = {
             type: "error",
-            messge: `unexpected response: ${res.statusText}`,
+            message: `unexpected response: ${res.statusText}`,
             status,
             ct,
           }

--- a/tex/document.go
+++ b/tex/document.go
@@ -91,7 +91,7 @@ func (w *fileWriter) Close() error {
 }
 
 // A Document outlines the methods needed to create a PDF file from TeX
-// sources, whithin the context of TeX.
+// sources, within the context of TeX.
 type Document interface {
 	// WorkingDirectory returns the path to a random directory, for
 	// AddFile and NewWriter to place new files in it. Compilation will
@@ -146,7 +146,7 @@ type Document interface {
 	// compiler. Candidates taken from .tex files in the root working
 	// directory:
 	//	- highest precedence have files starting with a "%!texd" mark
-	//	- if none ot those exists, use files with a \documentclass in the
+	//	- if none of those exists, use files with a \documentclass in the
 	//	  first 1 KiB
 	//	- if none of those exists, assume any remaining file could be
 	//	  a main input file.


### PR DESCRIPTION
Found via `codespell -S ./service -L ot,ons,fo` and `typos --hidden --format brief`